### PR TITLE
Additional checks to correctly place punctuation in relation to numbers.

### DIFF
--- a/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
@@ -111,15 +111,18 @@ namespace RTLTMPro
                         bool isBeforeRTLCharacter = Char32Utils.IsRTLCharacter(nextCharacter);
                         bool isBeforeWhiteSpace = Char32Utils.IsWhiteSpace(nextCharacter);
                         bool isAfterWhiteSpace = Char32Utils.IsWhiteSpace(previousCharacter);
+                        bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
                         bool isSpecialPunctuation = characterAtThisIndex == '.' ||
                                                     characterAtThisIndex == '،' ||
-                                                    characterAtThisIndex == '؛';
+                                                    characterAtThisIndex == '؛' ||
+                                                    characterAtThisIndex == '؟';
 
                         if (isBeforeRTLCharacter && isAfterRTLCharacter ||
                             isAfterWhiteSpace && isSpecialPunctuation ||
                             isBeforeWhiteSpace && isAfterRTLCharacter ||
                             isBeforeRTLCharacter && isAfterWhiteSpace ||
+                            isBeforeWhiteSpace && isAfterNumber && isSpecialPunctuation ||
                             (isBeforeRTLCharacter || isAfterRTLCharacter) && isUnderline)
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
@@ -130,7 +133,23 @@ namespace RTLTMPro
                         }
                     } else if (isAtEnd)
                     {
-                        LtrTextHolder.Add(characterAtThisIndex);
+                        // Check to see if the punctuation comes at the end of the string and follows a number
+                        bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
+                        bool isSpecialPunctuation = characterAtThisIndex == '.' ||
+                                                    characterAtThisIndex == '،' ||
+                                                    characterAtThisIndex == '؛' ||
+                                                    characterAtThisIndex == '؟';
+
+                        if (isAfterNumber && isSpecialPunctuation)
+                        {
+                            FlushBufferToOutput(LtrTextHolder, output);
+                            output.Append(characterAtThisIndex);
+                        }
+                        else
+                        {
+                            LtrTextHolder.Add(characterAtThisIndex);
+                        }
+
                     } else if (isAtBeginning)
                     {
                         output.Append(characterAtThisIndex);

--- a/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
@@ -113,10 +113,7 @@ namespace RTLTMPro
                         bool isAfterWhiteSpace = Char32Utils.IsWhiteSpace(previousCharacter);
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
-                        bool isSpecialPunctuation = characterAtThisIndex == '.' ||
-                                                    characterAtThisIndex == '،' ||
-                                                    characterAtThisIndex == '؛' ||
-                                                    characterAtThisIndex == '؟';
+                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
 
                         if (isBeforeRTLCharacter && isAfterRTLCharacter ||
                             isAfterWhiteSpace && isSpecialPunctuation ||
@@ -135,10 +132,7 @@ namespace RTLTMPro
                     {
                         // Check to see if the punctuation comes at the end of the string and follows a number
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
-                        bool isSpecialPunctuation = characterAtThisIndex == '.' ||
-                                                    characterAtThisIndex == '،' ||
-                                                    characterAtThisIndex == '؛' ||
-                                                    characterAtThisIndex == '؟';
+                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
 
                         if (isAfterNumber && isSpecialPunctuation)
                         {

--- a/UPMPackage/Scripts/Runtime/LigatureFixer.cs
+++ b/UPMPackage/Scripts/Runtime/LigatureFixer.cs
@@ -111,15 +111,15 @@ namespace RTLTMPro
                         bool isBeforeRTLCharacter = Char32Utils.IsRTLCharacter(nextCharacter);
                         bool isBeforeWhiteSpace = Char32Utils.IsWhiteSpace(nextCharacter);
                         bool isAfterWhiteSpace = Char32Utils.IsWhiteSpace(previousCharacter);
+                        bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
-                        bool isSpecialPunctuation = characterAtThisIndex == '.' ||
-                                                    characterAtThisIndex == '،' ||
-                                                    characterAtThisIndex == '؛';
+                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
 
                         if (isBeforeRTLCharacter && isAfterRTLCharacter ||
                             isAfterWhiteSpace && isSpecialPunctuation ||
                             isBeforeWhiteSpace && isAfterRTLCharacter ||
                             isBeforeRTLCharacter && isAfterWhiteSpace ||
+                            isBeforeWhiteSpace && isAfterNumber && isSpecialPunctuation ||
                             (isBeforeRTLCharacter || isAfterRTLCharacter) && isUnderline)
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
@@ -130,7 +130,20 @@ namespace RTLTMPro
                         }
                     } else if (isAtEnd)
                     {
-                        LtrTextHolder.Add(characterAtThisIndex);
+                        // Check to see if the punctuation comes at the end of the string and follows a number
+                        bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
+                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
+
+                        if (isAfterNumber && isSpecialPunctuation)
+                        {
+                            FlushBufferToOutput(LtrTextHolder, output);
+                            output.Append(characterAtThisIndex);
+                        }
+                        else
+                        {
+                            LtrTextHolder.Add(characterAtThisIndex);
+                        }
+
                     } else if (isAtBeginning)
                     {
                         output.Append(characterAtThisIndex);


### PR DESCRIPTION
Punctuation that followed numbers was placed incorrectly. The update adds checks for periods, commas, colons, and question marks that follow numbers. Separate checks are required for punctuation that appears in the middle of strings or at the end.

Before update:
![image](https://github.com/engage-xr/RTLTMPro/assets/98825945/a3ede5e6-dd1e-40d1-86ba-d73accd1fa43)

After update:
![image](https://github.com/engage-xr/RTLTMPro/assets/98825945/f9a370e8-a389-4c5b-9164-c8ee978c53be)
