### PR TITLE
Fixed ordering of quotation marks next to punctuation and symbols

### DIFF
--- a/Assets/RTLTMPro/Scripts/Runtime/Char32Utils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/Char32Utils.cs
@@ -48,6 +48,10 @@ namespace RTLTMPro {
             return char.IsWhiteSpace((char)ch);
         }
 
-        
+        public static bool IsQuote(int ch)
+        {
+            if (!IsUnicode16Char(ch)) return false;
+            return TextUtils.IsQuote((char)ch);
+        }
     }
 }

--- a/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
@@ -11,7 +11,7 @@ namespace RTLTMPro
             ['('] = ')',
             [')'] = '(',
             ['»'] = '«',
-            ['«'] = '»',
+            ['«'] = '»'
         };
         private static readonly HashSet<char> MirroredCharsSet = new HashSet<char>(MirroredCharsMap.Keys);
         private static void FlushBufferToOutput(List<int> buffer, FastStringBuilder output)
@@ -114,13 +114,17 @@ namespace RTLTMPro
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
                         bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
+                        bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
+                        bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
 
                         if (isBeforeRTLCharacter && isAfterRTLCharacter ||
                             isAfterWhiteSpace && isSpecialPunctuation ||
                             isBeforeWhiteSpace && isAfterRTLCharacter ||
                             isBeforeRTLCharacter && isAfterWhiteSpace ||
                             isBeforeWhiteSpace && isAfterNumber && isSpecialPunctuation ||
-                            (isBeforeRTLCharacter || isAfterRTLCharacter) && isUnderline)
+                            isBeforeQuote ||
+                            isAfterQuote  ||
+                            (isBeforeRTLCharacter || isAfterRTLCharacter) && isUnderline) 
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
                             output.Append(characterAtThisIndex);
@@ -130,11 +134,15 @@ namespace RTLTMPro
                         }
                     } else if (isAtEnd)
                     {
-                        // Check to see if the punctuation comes at the end of the string and follows a number
+                        // Check if the punctuation comes at the end of the string and follows a number
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
 
-                        if (isAfterNumber && isSpecialPunctuation)
+                        // Check if the punctuation comes at the end of the string and follows a quotation mark
+                        bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
+
+                        if (isAfterNumber && isSpecialPunctuation ||
+                            isAfterQuote && isSpecialPunctuation)
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
                             output.Append(characterAtThisIndex);

--- a/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
@@ -152,8 +152,7 @@ namespace RTLTMPro
                         // Check if the punctuation comes at the end of the string and follows a quotation mark
                         bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
 
-                        if (isAfterNumber && isSpecialPunctuation ||
-                            isAfterQuote && isSpecialPunctuation)
+                        if (isSpecialPunctuation && (isAfterNumber || isAfterQuote))
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
                             output.Append(characterAtThisIndex);

--- a/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
@@ -98,8 +98,13 @@ namespace RTLTMPro
                         // IsRTLCharacter returns false for null
                         bool isAfterRTLCharacter = Char32Utils.IsRTLCharacter(previousCharacter);
                         bool isBeforeRTLCharacter = Char32Utils.IsRTLCharacter(nextCharacter);
+                        bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);                 // Corrects reversed brackets next to quote marks
+                        bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
 
-                        if (isAfterRTLCharacter || isBeforeRTLCharacter)
+                        //bool isAfterQuote = false;
+                        //bool isBeforeQuote = false;
+
+                        if (isAfterRTLCharacter || isBeforeRTLCharacter || isAfterQuote || isBeforeQuote)
                         {
                             characterAtThisIndex = MirroredCharsMap[(char)characterAtThisIndex];
                         }
@@ -114,16 +119,25 @@ namespace RTLTMPro
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
                         bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
+                        bool isBeforeSpecialPunctuation = nextCharacter is '.' or '،' or '؛' or '؟';
                         bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
                         bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
+                        bool isClosingBracket = characterAtThisIndex is '(';
+                        bool isOpeningBracket = characterAtThisIndex is ')';
+                        bool isBeforeBracket = nextCharacter is ')' or '(';
+                        bool isAfterBracket = previousCharacter is ')' or '(';
+                        bool isQuote = Char32Utils.IsQuote(characterAtThisIndex);
 
                         if (isBeforeRTLCharacter && isAfterRTLCharacter ||
                             isAfterWhiteSpace && isSpecialPunctuation ||
                             isBeforeWhiteSpace && isAfterRTLCharacter ||
                             isBeforeRTLCharacter && isAfterWhiteSpace ||
                             isBeforeWhiteSpace && isAfterNumber && isSpecialPunctuation ||
-                            isBeforeQuote ||
-                            isAfterQuote  ||
+                            isClosingBracket && isBeforeQuote ||                            // Corrects "( in "(المريخ)"
+                            isOpeningBracket && isAfterQuote ||                             // Corrects )" in "(المريخ)"
+                            isQuote && isAfterBracket ||                                    // Corrects ") in .("المريخ") and :"( in :"(المريخ)":
+                            isQuote && isBeforeBracket ||                                   // Corrects (" in ("المريخ") and )": in :"(المريخ)":
+                            isClosingBracket && isBeforeSpecialPunctuation ||               // Corrects .( in .(المريخ)
                             (isBeforeRTLCharacter || isAfterRTLCharacter) && isUnderline) 
                         {
                             FlushBufferToOutput(LtrTextHolder, output);

--- a/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
@@ -101,9 +101,6 @@ namespace RTLTMPro
                         bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);                 // Corrects reversed brackets next to quote marks
                         bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
 
-                        //bool isAfterQuote = false;
-                        //bool isBeforeQuote = false;
-
                         if (isAfterRTLCharacter || isBeforeRTLCharacter || isAfterQuote || isBeforeQuote)
                         {
                             characterAtThisIndex = MirroredCharsMap[(char)characterAtThisIndex];

--- a/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
@@ -79,6 +79,12 @@ namespace RTLTMPro
                 || ch >= ArabicPresentationFormsBBlockLow && ch <= ArabicPresentationFormsBBlockHigh;
         }
 
+        // Checks if the character is a quote symbol. Either the generic " or guillemets
+        public static bool IsQuote(char input)
+        {
+            return input is '"' or '«' or '»';
+        }
+
         /// <summary>
         ///     Checks if the character is supported RTL character.
         /// </summary>

--- a/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
@@ -31,6 +31,9 @@ namespace RTLTMPro
         private const char ArabicPresentationFormsBBlockLow  = (char)0xFE70;
         private const char ArabicPresentationFormsBBlockHigh = (char)0xFEFF;
 
+        private const char LeftGuillemet = '\u00AB';  // «
+        private const char RightGuillemet = '\u00BB'; // »
+
         public static bool IsPunctuation(char ch)
         {
             throw new NotImplementedException();
@@ -82,7 +85,7 @@ namespace RTLTMPro
         // Checks if the character is a quote symbol. Either the generic " or guillemets
         public static bool IsQuote(char input)
         {
-            return input is '"' or '«' or '»';
+            return input is '"' or LeftGuillemet or RightGuillemet;
         }
 
         /// <summary>

--- a/UPMPackage/Scripts/Runtime/Char32Utils.cs
+++ b/UPMPackage/Scripts/Runtime/Char32Utils.cs
@@ -48,6 +48,10 @@ namespace RTLTMPro {
             return char.IsWhiteSpace((char)ch);
         }
 
-        
+        public static bool IsQuote(int ch)
+        {
+            if (!IsUnicode16Char(ch)) return false;
+            return TextUtils.IsQuote((char)ch);
+        }
     }
 }

--- a/UPMPackage/Scripts/Runtime/LigatureFixer.cs
+++ b/UPMPackage/Scripts/Runtime/LigatureFixer.cs
@@ -152,8 +152,7 @@ namespace RTLTMPro
                         // Check if the punctuation comes at the end of the string and follows a quotation mark
                         bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
 
-                        if (isAfterNumber && isSpecialPunctuation ||
-                            isAfterQuote && isSpecialPunctuation)
+                        if (isSpecialPunctuation && (isAfterNumber || isAfterQuote))
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
                             output.Append(characterAtThisIndex);

--- a/UPMPackage/Scripts/Runtime/LigatureFixer.cs
+++ b/UPMPackage/Scripts/Runtime/LigatureFixer.cs
@@ -11,7 +11,7 @@ namespace RTLTMPro
             ['('] = ')',
             [')'] = '(',
             ['»'] = '«',
-            ['«'] = '»',
+            ['«'] = '»'
         };
         private static readonly HashSet<char> MirroredCharsSet = new HashSet<char>(MirroredCharsMap.Keys);
         private static void FlushBufferToOutput(List<int> buffer, FastStringBuilder output)
@@ -98,8 +98,13 @@ namespace RTLTMPro
                         // IsRTLCharacter returns false for null
                         bool isAfterRTLCharacter = Char32Utils.IsRTLCharacter(previousCharacter);
                         bool isBeforeRTLCharacter = Char32Utils.IsRTLCharacter(nextCharacter);
+                        bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);                 // Corrects reversed brackets next to quote marks
+                        bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
 
-                        if (isAfterRTLCharacter || isBeforeRTLCharacter)
+                        //bool isAfterQuote = false;
+                        //bool isBeforeQuote = false;
+
+                        if (isAfterRTLCharacter || isBeforeRTLCharacter || isAfterQuote || isBeforeQuote)
                         {
                             characterAtThisIndex = MirroredCharsMap[(char)characterAtThisIndex];
                         }
@@ -114,13 +119,26 @@ namespace RTLTMPro
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
                         bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
+                        bool isBeforeSpecialPunctuation = nextCharacter is '.' or '،' or '؛' or '؟';
+                        bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
+                        bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
+                        bool isClosingBracket = characterAtThisIndex is '(';
+                        bool isOpeningBracket = characterAtThisIndex is ')';
+                        bool isBeforeBracket = nextCharacter is ')' or '(';
+                        bool isAfterBracket = previousCharacter is ')' or '(';
+                        bool isQuote = Char32Utils.IsQuote(characterAtThisIndex);
 
                         if (isBeforeRTLCharacter && isAfterRTLCharacter ||
                             isAfterWhiteSpace && isSpecialPunctuation ||
                             isBeforeWhiteSpace && isAfterRTLCharacter ||
                             isBeforeRTLCharacter && isAfterWhiteSpace ||
                             isBeforeWhiteSpace && isAfterNumber && isSpecialPunctuation ||
-                            (isBeforeRTLCharacter || isAfterRTLCharacter) && isUnderline)
+                            isClosingBracket && isBeforeQuote ||                            // Corrects "( in "(المريخ)"
+                            isOpeningBracket && isAfterQuote ||                             // Corrects )" in "(المريخ)"
+                            isQuote && isAfterBracket ||                                    // Corrects ") in .("المريخ") and :"( in :"(المريخ)":
+                            isQuote && isBeforeBracket ||                                   // Corrects (" in ("المريخ") and )": in :"(المريخ)":
+                            isClosingBracket && isBeforeSpecialPunctuation ||               // Corrects .( in .(المريخ)
+                            (isBeforeRTLCharacter || isAfterRTLCharacter) && isUnderline) 
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
                             output.Append(characterAtThisIndex);
@@ -130,11 +148,15 @@ namespace RTLTMPro
                         }
                     } else if (isAtEnd)
                     {
-                        // Check to see if the punctuation comes at the end of the string and follows a number
+                        // Check if the punctuation comes at the end of the string and follows a number
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
 
-                        if (isAfterNumber && isSpecialPunctuation)
+                        // Check if the punctuation comes at the end of the string and follows a quotation mark
+                        bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
+
+                        if (isAfterNumber && isSpecialPunctuation ||
+                            isAfterQuote && isSpecialPunctuation)
                         {
                             FlushBufferToOutput(LtrTextHolder, output);
                             output.Append(characterAtThisIndex);

--- a/UPMPackage/Scripts/Runtime/LigatureFixer.cs
+++ b/UPMPackage/Scripts/Runtime/LigatureFixer.cs
@@ -101,9 +101,6 @@ namespace RTLTMPro
                         bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);                 // Corrects reversed brackets next to quote marks
                         bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
 
-                        //bool isAfterQuote = false;
-                        //bool isBeforeQuote = false;
-
                         if (isAfterRTLCharacter || isBeforeRTLCharacter || isAfterQuote || isBeforeQuote)
                         {
                             characterAtThisIndex = MirroredCharsMap[(char)characterAtThisIndex];

--- a/UPMPackage/Scripts/Runtime/TextUtils.cs
+++ b/UPMPackage/Scripts/Runtime/TextUtils.cs
@@ -79,6 +79,12 @@ namespace RTLTMPro
                 || ch >= ArabicPresentationFormsBBlockLow && ch <= ArabicPresentationFormsBBlockHigh;
         }
 
+        // Checks if the character is a quote symbol. Either the generic " or guillemets
+        public static bool IsQuote(char input)
+        {
+            return input is '"' or '«' or '»';
+        }
+
         /// <summary>
         ///     Checks if the character is supported RTL character.
         /// </summary>

--- a/UPMPackage/Scripts/Runtime/TextUtils.cs
+++ b/UPMPackage/Scripts/Runtime/TextUtils.cs
@@ -31,6 +31,9 @@ namespace RTLTMPro
         private const char ArabicPresentationFormsBBlockLow  = (char)0xFE70;
         private const char ArabicPresentationFormsBBlockHigh = (char)0xFEFF;
 
+        private const char LeftGuillemet = '\u00AB';  // «
+        private const char RightGuillemet = '\u00BB'; // »
+
         public static bool IsPunctuation(char ch)
         {
             throw new NotImplementedException();
@@ -82,7 +85,7 @@ namespace RTLTMPro
         // Checks if the character is a quote symbol. Either the generic " or guillemets
         public static bool IsQuote(char input)
         {
-            return input is '"' or '«' or '»';
+            return input is '"' or LeftGuillemet or RightGuillemet;
         }
 
         /// <summary>


### PR DESCRIPTION
Test strings:
![image](https://github.com/engage-xr/RTLTMPro/assets/98825945/afd360c3-0a09-47bb-a28f-56b04d60dd63)
