### PR TITLE
EN-43380 / Flipped Mixed Characters Equals

### DIFF
--- a/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/LigatureFixer.cs
@@ -115,8 +115,8 @@ namespace RTLTMPro
                         bool isAfterWhiteSpace = Char32Utils.IsWhiteSpace(previousCharacter);
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
-                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
-                        bool isBeforeSpecialPunctuation = nextCharacter is '.' or '،' or '؛' or '؟';
+                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟' or '=';
+                        bool isBeforeSpecialPunctuation = nextCharacter is '.' or '،' or '؛' or '؟' or '=';
                         bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
                         bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
                         bool isClosingBracket = characterAtThisIndex is '(';

--- a/UPMPackage/Scripts/Runtime/LigatureFixer.cs
+++ b/UPMPackage/Scripts/Runtime/LigatureFixer.cs
@@ -115,8 +115,8 @@ namespace RTLTMPro
                         bool isAfterWhiteSpace = Char32Utils.IsWhiteSpace(previousCharacter);
                         bool isAfterNumber = Char32Utils.IsNumber(previousCharacter, preserveNumbers, farsi);
                         bool isUnderline = characterAtThisIndex == '_';
-                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟';
-                        bool isBeforeSpecialPunctuation = nextCharacter is '.' or '،' or '؛' or '؟';
+                        bool isSpecialPunctuation = characterAtThisIndex is '.' or '،' or '؛' or '؟' or '=';
+                        bool isBeforeSpecialPunctuation = nextCharacter is '.' or '،' or '؛' or '؟' or '=';
                         bool isAfterQuote = Char32Utils.IsQuote(previousCharacter);
                         bool isBeforeQuote = Char32Utils.IsQuote(nextCharacter);
                         bool isClosingBracket = characterAtThisIndex is '(';


### PR DESCRIPTION
EN-43380 When mixing LTR and RTL, using Force Fix usually helps. However, in the case of the string LB = إعادة توسيط the result put the '=' on the wrong side of the string as it wasn't treated as RTL punctuation.