### PR TITLE
EN-43166 / Mixed Language didn't work when started LTR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ crashlytics-build.properties
 # Raw image files
 *.xcf
 UserSettings
+*.DS_Store

--- a/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
@@ -432,7 +432,7 @@ namespace RTLTMPro
 
                 if (char.IsLetter(character))
                 {
-                    return IsRTLCharacter(character);
+                    if (IsRTLCharacter(character)) return true;
                 }
             }
 

--- a/UPMPackage/Scripts/Runtime/TextUtils.cs
+++ b/UPMPackage/Scripts/Runtime/TextUtils.cs
@@ -432,7 +432,7 @@ namespace RTLTMPro
 
                 if (char.IsLetter(character))
                 {
-                    return IsRTLCharacter(character);
+                    if (IsRTLCharacter(character)) return true;
                 }
             }
 


### PR DESCRIPTION
EN-43166 The check for IsRTL was only returning the first character in the string. Changed the check now to return true whenever an RTL character is found in the string.