### PR TITLE
Code to prevent duplicate processing.

### DIFF
--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
@@ -94,6 +94,8 @@ namespace RTLTMPro
 
         protected readonly FastStringBuilder finalText = new FastStringBuilder(RTLSupport.DefaultBufferSize);
 
+        protected string resultOfLastProcess = null;
+
         protected void Update()
         {
             if (havePropertiesChanged)
@@ -111,10 +113,12 @@ namespace RTLTMPro
             {
                 isRightToLeftText = false;
                 base.text = originalText;
-            } else
+            } else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
+
+                resultOfLastProcess = base.text;            // Store the processed string
             }
 
             havePropertiesChanged = true;

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -94,6 +94,8 @@ namespace RTLTMPro
 
         protected readonly FastStringBuilder finalText = new FastStringBuilder(RTLSupport.DefaultBufferSize);
 
+        protected string resultOfLastProcess = null;
+
         protected void Update()
         {
             if (havePropertiesChanged)
@@ -112,10 +114,12 @@ namespace RTLTMPro
                 isRightToLeftText = false;
                 base.text = originalText;
             }
-            else
+            else if (originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
+
+                resultOfLastProcess = base.text;            // Store the processed string
             }
 
             havePropertiesChanged = true;

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
@@ -94,6 +94,8 @@ namespace RTLTMPro
 
         protected readonly FastStringBuilder finalText = new FastStringBuilder(RTLSupport.DefaultBufferSize);
 
+        protected string resultOfLastProcess = null;
+
         protected void Update()
         {
             if (havePropertiesChanged)
@@ -111,10 +113,12 @@ namespace RTLTMPro
             {
                 isRightToLeftText = false;
                 base.text = originalText;
-            } else
+            } else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
+
+                resultOfLastProcess = base.text;            // Store the processed string
             }
 
             havePropertiesChanged = true;

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -94,6 +94,8 @@ namespace RTLTMPro
 
         protected readonly FastStringBuilder finalText = new FastStringBuilder(RTLSupport.DefaultBufferSize);
 
+        protected string resultOfLastProcess = null;
+
         protected void Update()
         {
             if (havePropertiesChanged)
@@ -112,10 +114,12 @@ namespace RTLTMPro
                 isRightToLeftText = false;
                 base.text = originalText;
             }
-            else
+            else if (originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
+
+                resultOfLastProcess = base.text;            // Store the processed string
             }
 
             havePropertiesChanged = true;


### PR DESCRIPTION
The problem is that the code to process the string is being run twice. The second execution seems to be triggered by the hover event.

The first run correctly processes the string.

The second run takes the already processed string and breaks it.

Barry tested a version of this solution and it seemed to work, but it would need more testing in the ENGAGE project.

**Note**: The fix may not be needed if we can prevent the second processing on the Gizmo strings. There's a flag in RTLTextMeshPro.UpdateText that should probably be set to false after the update. That may be enough to prevent multiple processing.