### PR TITLE
RTL in LTR chunking

### DIFF
--- a/Assets/RTLTMPro/Scripts/Editor/RTLTextMeshPro3DEditor.cs
+++ b/Assets/RTLTMPro/Scripts/Editor/RTLTextMeshPro3DEditor.cs
@@ -11,7 +11,6 @@ namespace RTLTMPro
         private SerializedProperty preserveNumbersProp;
         private SerializedProperty farsiProp;
         private SerializedProperty fixTagsProp;
-        private SerializedProperty forceFixProp;
 
         private bool foldout;
         private RTLTextMeshPro3D tmpro;
@@ -23,7 +22,6 @@ namespace RTLTMPro
             preserveNumbersProp = serializedObject.FindProperty("preserveNumbers");
             farsiProp = serializedObject.FindProperty("farsi");
             fixTagsProp = serializedObject.FindProperty("fixTags");
-            forceFixProp = serializedObject.FindProperty("forceFix");
             originalTextProp = serializedObject.FindProperty("originalText");
         }
 
@@ -77,7 +75,6 @@ namespace RTLTMPro
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginChangeCheck();
             farsiProp.boolValue = GUILayout.Toggle(farsiProp.boolValue, new GUIContent("Farsi"));
-            forceFixProp.boolValue = GUILayout.Toggle(forceFixProp.boolValue, new GUIContent("Force Fix"));
             preserveNumbersProp.boolValue = GUILayout.Toggle(preserveNumbersProp.boolValue, new GUIContent("Preserve Numbers"));
 
             if (tmpro.richText)

--- a/Assets/RTLTMPro/Scripts/Editor/RTLTextMeshProEditor.cs
+++ b/Assets/RTLTMPro/Scripts/Editor/RTLTextMeshProEditor.cs
@@ -17,7 +17,6 @@ namespace RTLTMPro
         private SerializedProperty preserveNumbersProp;
         private SerializedProperty farsiProp;
         private SerializedProperty fixTagsProp;
-        private SerializedProperty forceFixProp;
 
         private bool foldout;
         private RTLTextMeshPro tmpro;
@@ -29,7 +28,6 @@ namespace RTLTMPro
             preserveNumbersProp = serializedObject.FindProperty("preserveNumbers");
             farsiProp = serializedObject.FindProperty("farsi");
             fixTagsProp = serializedObject.FindProperty("fixTags");
-            forceFixProp = serializedObject.FindProperty("forceFix");
             originalTextProp = serializedObject.FindProperty("originalText");
         }
 
@@ -83,7 +81,6 @@ namespace RTLTMPro
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginChangeCheck();
             farsiProp.boolValue = GUILayout.Toggle(farsiProp.boolValue, new GUIContent("Farsi"));
-            forceFixProp.boolValue = GUILayout.Toggle(forceFixProp.boolValue, new GUIContent("Force Fix"));
             preserveNumbersProp.boolValue = GUILayout.Toggle(preserveNumbersProp.boolValue, new GUIContent("Preserve Numbers"));
 
             if (tmpro.richText)

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTMPro.asmdef
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTMPro.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "RTLTMPro",
+    "rootNamespace": "",
     "references": [
-        "Unity.TextMeshPro"
+        "Unity.TextMeshPro",
+        "Unity.Localization"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
@@ -114,7 +114,8 @@ namespace RTLTMPro
             {
                 isRightToLeftText = false;
                 base.text = GetChunkFixedText(originalText);
-            } else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
+            } 
+            else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
@@ -130,7 +131,7 @@ namespace RTLTMPro
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            string recombinedString = "";
+            FastStringBuilder recombinedString = new FastStringBuilder("");
             List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
 
             FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
@@ -149,7 +150,7 @@ namespace RTLTMPro
                 }
                 else
                 {
-                    recombinedString += chunks[i];  // If LTR chunk, just append
+                    recombinedString += chunks[i]; // If LTR chunk, just append
                 }
             }
 

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
@@ -1,5 +1,6 @@
 ﻿using TMPro;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace RTLTMPro
 {
@@ -112,7 +113,7 @@ namespace RTLTMPro
             if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
             {
                 isRightToLeftText = false;
-                base.text = originalText;
+                base.text = GetChunkFixedText(originalText);
             } else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
@@ -122,6 +123,37 @@ namespace RTLTMPro
             }
 
             havePropertiesChanged = true;
+        }
+
+        private string GetChunkFixedText(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            string recombinedString = "";
+            List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
+
+            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+
+            // Loop over chunks. Fix RTL and just append LTR
+            for (int i = 0; i < chunks.Count; i++)
+            {
+                if (TextUtils.IsRTLInput(chunks[i]))
+                {
+                    arChunkFixer.Clear();
+
+                    // Fix the Arabic block of text
+                    RTLSupport.FixRTL(chunks[i], arChunkFixer, farsi, fixTags, preserveNumbers);
+
+                    recombinedString += arChunkFixer.ToString();
+                }
+                else
+                {
+                    recombinedString += chunks[i];  // If LTR chunk, just append
+                }
+            }
+
+            return recombinedString;
         }
 
         private string GetFixedText(string input)

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro.cs
@@ -1,6 +1,7 @@
-﻿using TMPro;
+﻿using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
-using System.Collections.Generic;
+using UnityEngine.Localization.Settings;
 
 namespace RTLTMPro
 {
@@ -70,17 +71,9 @@ namespace RTLTMPro
             }
         }
 
-        public bool ForceFix
+        private static bool ForceFix
         {
-            get { return forceFix; }
-            set
-            {
-                if (forceFix == value)
-                    return;
-
-                forceFix = value;
-                havePropertiesChanged = true;
-            }
+            get => LocalizationSettings.SelectedLocale != null && LocalizationSettings.SelectedLocale.Identifier.CultureInfo.TextInfo.IsRightToLeft;
         }
 
         [SerializeField] protected bool preserveNumbers = true;
@@ -110,7 +103,7 @@ namespace RTLTMPro
             if (originalText == null)
                 originalText = "";
 
-            if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
+            if (!ForceFix)
             {
                 isRightToLeftText = false;
                 base.text = GetChunkFixedText(originalText);

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -131,15 +131,14 @@ namespace RTLTMPro
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
-
-            string recombinedString = "";
+            FastStringBuilder recombinedString = new FastStringBuilder("");
             List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
+
+            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
 
             // Loop over chunks. Fix RTL and just append LTR
             for (int i = 0; i < chunks.Count; i++)
             {
-
                 if (TextUtils.IsRTLInput(chunks[i]))
                 {
                     arChunkFixer.Clear();
@@ -151,7 +150,7 @@ namespace RTLTMPro
                 }
                 else
                 {
-                    recombinedString += chunks[i];  // If LTR chunk, just append
+                    recombinedString += chunks[i]; // If LTR chunk, just append
                 }
             }
 

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -1,6 +1,7 @@
-﻿using TMPro;
+﻿using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
-using System.Collections.Generic;
+using UnityEngine.Localization.Settings;
 
 namespace RTLTMPro
 {
@@ -70,17 +71,9 @@ namespace RTLTMPro
             }
         }
 
-        protected bool ForceFix
+        private static bool ForceFix
         {
-            get { return forceFix; }
-            set
-            {
-                if (forceFix == value)
-                    return;
-
-                forceFix = value;
-                havePropertiesChanged = true;
-            }
+            get => LocalizationSettings.SelectedLocale != null && LocalizationSettings.SelectedLocale.Identifier.CultureInfo.TextInfo.IsRightToLeft;
         }
 
         [SerializeField] protected bool preserveNumbers;
@@ -110,11 +103,11 @@ namespace RTLTMPro
             if (originalText == null)
                 originalText = "";
 
-            if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
+            if (!ForceFix)
             {
                 isRightToLeftText = false;
                 base.text = GetChunkFixedText(originalText);
-            }
+            } 
             else if (originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
@@ -165,7 +158,6 @@ namespace RTLTMPro
             finalText.Clear();
             RTLSupport.FixRTL(input, finalText, farsi, fixTags, preserveNumbers);
             finalText.Reverse();
-
             return finalText.ToString();
         }
     }

--- a/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -1,5 +1,6 @@
 ﻿using TMPro;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace RTLTMPro
 {
@@ -112,7 +113,7 @@ namespace RTLTMPro
             if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
             {
                 isRightToLeftText = false;
-                base.text = originalText;
+                base.text = GetChunkFixedText(originalText);
             }
             else if (originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
@@ -123,6 +124,38 @@ namespace RTLTMPro
             }
 
             havePropertiesChanged = true;
+        }
+
+        private string GetChunkFixedText(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+
+            string recombinedString = "";
+            List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
+
+            // Loop over chunks. Fix RTL and just append LTR
+            for (int i = 0; i < chunks.Count; i++)
+            {
+
+                if (TextUtils.IsRTLInput(chunks[i]))
+                {
+                    arChunkFixer.Clear();
+
+                    // Fix the Arabic block of text
+                    RTLSupport.FixRTL(chunks[i], arChunkFixer, farsi, fixTags, preserveNumbers);
+
+                    recombinedString += arChunkFixer.ToString();
+                }
+                else
+                {
+                    recombinedString += chunks[i];  // If LTR chunk, just append
+                }
+            }
+
+            return recombinedString;
         }
 
         private string GetFixedText(string input)

--- a/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
@@ -455,8 +455,13 @@ namespace RTLTMPro
                 // Loop and add a chunk each time that the text switches between RTL and LTR
                 for (int i = 1; i < input.Length; i++)      //  Start at char 1
                 {
-                    if (IsRTLCharacter(input[i]) == rtlChunk){
-
+                    //if (IsRTLCharacter(input[i]) == rtlChunk){
+                    if (IsRTLCharacter(input[i]) == rtlChunk)
+                    {
+                        buffer += input[i];
+                    }
+                    else if (input[i] == ' ')   // Prevent space breaking Arabic strings into chunks
+                    {
                         buffer += input[i];
                     }
                     else

--- a/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections;
 
 namespace RTLTMPro
 {
@@ -432,11 +433,54 @@ namespace RTLTMPro
 
                 if (char.IsLetter(character))
                 {
-                    if (IsRTLCharacter(character)) return true;
+                    //if (IsRTLCharacter(character)) return true;
+
+                    return IsRTLCharacter(character);
                 }
             }
 
             return false;
+        }
+
+        public static List<string> SplitLtrRtlChunks(string input)
+        {
+            List<string> chunks = new List<string>();
+
+            if (input.Length > 0)
+            {
+                string buffer = "";
+                buffer += input[0];                         // Initialise with char 0
+                bool rtlChunk = IsRTLCharacter(input[0]);
+
+                // Loop and add a chunk each time that the text switches between RTL and LTR
+                for (int i = 1; i < input.Length; i++)      //  Start at char 1
+                {
+                    if (IsRTLCharacter(input[i]) == rtlChunk){
+
+                        buffer += input[i];
+                    }
+                    else
+                    {
+                        // Change between RTL and LTR
+                        chunks.Add(buffer);
+
+                        buffer = "";
+                        buffer += input[i];
+                        rtlChunk = IsRTLCharacter(input[i]);
+                    }
+                }
+
+                if (buffer.Length > 0)  // Flush the buffer
+                {
+                    chunks.Add(buffer);
+                }
+            }
+            else
+            {
+                chunks.Add(input);  // Adding an empty string
+            }
+
+            return chunks;
         }
     }
 }

--- a/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/TextUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections;
 
 namespace RTLTMPro
 {
@@ -32,8 +31,8 @@ namespace RTLTMPro
         private const char ArabicPresentationFormsBBlockLow  = (char)0xFE70;
         private const char ArabicPresentationFormsBBlockHigh = (char)0xFEFF;
 
-        private const char LeftGuillemet = '\u00AB';  // «
-        private const char RightGuillemet = '\u00BB'; // »
+        private const char LeftGuillemet = '\u00AB';  // ï¿½
+        private const char RightGuillemet = '\u00BB'; // ï¿½
 
         public static bool IsPunctuation(char ch)
         {
@@ -407,7 +406,7 @@ namespace RTLTMPro
         }
         
         /// <summary>
-        ///     Checks if the input string starts with supported RTL character or not.
+        /// Checks if the input string starts with supported RTL character or not.
         /// </summary>
         /// <returns><see langword="true" /> if input is RTL. otherwise <see langword="false" /></returns>
         public static bool IsRTLInput(string input)
@@ -433,8 +432,6 @@ namespace RTLTMPro
 
                 if (char.IsLetter(character))
                 {
-                    //if (IsRTLCharacter(character)) return true;
-
                     return IsRTLCharacter(character);
                 }
             }
@@ -448,21 +445,38 @@ namespace RTLTMPro
 
             if (input.Length > 0)
             {
-                string buffer = "";
+                FastStringBuilder buffer = "";
                 buffer += input[0];                         // Initialise with char 0
                 bool rtlChunk = IsRTLCharacter(input[0]);
 
                 // Loop and add a chunk each time that the text switches between RTL and LTR
                 for (int i = 1; i < input.Length; i++)      //  Start at char 1
                 {
-                    //if (IsRTLCharacter(input[i]) == rtlChunk){
+                    if (input[i] == ' ' && i < input.Length - 1)
+                    {
+                        if (!rtlChunk)
+                        {
+                            buffer.Append(input[i]);
+                            continue;
+                        }
+                        
+                        if (IsRTLCharacter(input[i + 1]))
+                        {
+                            buffer.Append(input[i]);
+                        }
+                        else
+                        {
+                            chunks.Add(buffer);
+                            buffer.Clear();
+                            buffer.Append(input[i]);
+                            rtlChunk = false;
+                        }
+                        continue;
+                    }
+
                     if (IsRTLCharacter(input[i]) == rtlChunk)
                     {
-                        buffer += input[i];
-                    }
-                    else if (input[i] == ' ')   // Prevent space breaking Arabic strings into chunks
-                    {
-                        buffer += input[i];
+                        buffer.Append(input[i]);
                     }
                     else
                     {

--- a/Assets/RTLTMPro/Tests/EngageOrderingTests.cs
+++ b/Assets/RTLTMPro/Tests/EngageOrderingTests.cs
@@ -30,11 +30,23 @@ namespace RTLTMPro.Tests
         [TestCase("(المريخ).", ")ﺍﻟﻤﺮﯾﺦ(.")]
         [TestCase("هل أنت متأكد أنك تريد حذف \"موسيقىaaa\"؟", "ﻫﻞ ﺃﻧﺖ ﻣﺘﺄﻛﺪ ﺃﻧﻚ ﺗﺮﯾﺪ ﺣﺬﻑ \"ﻣﻮﺳﯿﻘﻰaaa\"؟")]
         [TestCase("هل أنت متأكد أنك تريد حذف \"aaaموسيقى\"؟", "ﻫﻞ ﺃﻧﺖ ﻣﺘﺄﻛﺪ ﺃﻧﻚ ﺗﺮﯾﺪ ﺣﺬﻑ \"aaaﻣﻮﺳﯿﻘﻰ\"؟")]
-        [TestCase("المحور المركزي لـ ENGAGE LINK. نحن نعقد جلسات \"تعلم ENGAGE\" هنا بشكل متكرر، بالإضافة إلى حلقات عمل وفعاليات تواصل أخرى. لمزيد من المعلومات، تحقق من لوحات الملاحظات.", "ﺍﻟﻤﺤﻮﺭ ﺍﻟﻤﺮﻛﺰﯼ ﻟـ KNIL EGAGNE. ﻧﺤﻦ ﻧﻌﻘﺪ ﺟﻠﺴﺎﺕ \"ﺗﻌﻠﻢ EGAGNE\" ﻫﻨﺎ ﺑﺸﻜﻞ ﻣﺘﻜﺮﺭ، ﺑﺎﻹﺿﺎﻓﺔ ﺇﻟﻰ ﺣﻠﻘﺎﺕ ﻋﻤﻞ ﻭﻓﻌﺎﻟﯿﺎﺕ ﺗﻮﺍﺻﻞ ﺃﺧﺮﻯ. ﻟﻤﺰﯾﺪ ﻣﻦ ﺍﻟﻤﻌﻠﻮﻣﺎﺕ، ﺗﺤﻘﻖ ﻣﻦ ﻟﻮﺣﺎﺕ ﺍﻟﻤﻼﺣﻈﺎﺕ.")]
         public void CharacterOrder(string input, string expected)
         {
             // Act
             string result = SimulatedUpdateText(input, true, true, true);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("A recording is in progress by عبد. Your voice, actions, and movements might be recorded.", "A recording is in progress by ﺪﺒﻋ. Your voice, actions, and movements might be recorded.")]
+        [TestCase("Bring all users to قاعة المحاضرات", "Bring all users to ﺕﺍﺮﺿﺎﺤﻤﻟﺍ ﺔﻋﺎﻗ")]
+        public void RTLTextInLTRStrings(string input, string expected)
+        {
+            // Act
+            RTLTextMeshPro rtlTMPro = new RTLTextMeshPro();
+            rtlTMPro.text = input;
+            string result = rtlTMPro.text;
 
             // Assert
             Assert.AreEqual(expected, result);

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -10,6 +10,7 @@
     "com.unity.ide.rider": "3.0.28",
     "com.unity.ide.visualstudio": "2.0.22",
     "com.unity.ide.vscode": "1.2.5",
+    "com.unity.localization": "1.5.2",
     "com.unity.test-framework": "1.1.33",
     "com.unity.textmeshpro": "3.0.8",
     "com.unity.timeline": "1.7.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -15,6 +15,20 @@
         "com.unity.modules.uielements": "1.0.0"
       }
     },
+    "com.unity.addressables": {
+      "version": "1.22.2",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.scriptablebuildpipeline": "1.21.24",
+        "com.unity.modules.assetbundle": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.unitywebrequest": "1.0.0",
+        "com.unity.modules.unitywebrequestassetbundle": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.ads": {
       "version": "4.4.2",
       "depth": 0,
@@ -82,9 +96,26 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.localization": {
+      "version": "1.5.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.addressables": "1.21.9",
+        "com.unity.nuget.newtonsoft-json": "3.0.2"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.nuget.newtonsoft-json": {
       "version": "3.2.1",
-      "depth": 3,
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.scriptablebuildpipeline": {
+      "version": "1.21.24",
+      "depth": 2,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"

--- a/UPMPackage/Scripts/Editor/RTLTextMeshPro3DEditor.cs
+++ b/UPMPackage/Scripts/Editor/RTLTextMeshPro3DEditor.cs
@@ -11,7 +11,6 @@ namespace RTLTMPro
         private SerializedProperty preserveNumbersProp;
         private SerializedProperty farsiProp;
         private SerializedProperty fixTagsProp;
-        private SerializedProperty forceFixProp;
 
         private bool foldout;
         private RTLTextMeshPro3D tmpro;
@@ -23,7 +22,6 @@ namespace RTLTMPro
             preserveNumbersProp = serializedObject.FindProperty("preserveNumbers");
             farsiProp = serializedObject.FindProperty("farsi");
             fixTagsProp = serializedObject.FindProperty("fixTags");
-            forceFixProp = serializedObject.FindProperty("forceFix");
             originalTextProp = serializedObject.FindProperty("originalText");
         }
 
@@ -77,7 +75,6 @@ namespace RTLTMPro
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginChangeCheck();
             farsiProp.boolValue = GUILayout.Toggle(farsiProp.boolValue, new GUIContent("Farsi"));
-            forceFixProp.boolValue = GUILayout.Toggle(forceFixProp.boolValue, new GUIContent("Force Fix"));
             preserveNumbersProp.boolValue = GUILayout.Toggle(preserveNumbersProp.boolValue, new GUIContent("Preserve Numbers"));
 
             if (tmpro.richText)

--- a/UPMPackage/Scripts/Editor/RTLTextMeshProEditor.cs
+++ b/UPMPackage/Scripts/Editor/RTLTextMeshProEditor.cs
@@ -17,7 +17,6 @@ namespace RTLTMPro
         private SerializedProperty preserveNumbersProp;
         private SerializedProperty farsiProp;
         private SerializedProperty fixTagsProp;
-        private SerializedProperty forceFixProp;
 
         private bool foldout;
         private RTLTextMeshPro tmpro;
@@ -29,7 +28,6 @@ namespace RTLTMPro
             preserveNumbersProp = serializedObject.FindProperty("preserveNumbers");
             farsiProp = serializedObject.FindProperty("farsi");
             fixTagsProp = serializedObject.FindProperty("fixTags");
-            forceFixProp = serializedObject.FindProperty("forceFix");
             originalTextProp = serializedObject.FindProperty("originalText");
         }
 
@@ -83,7 +81,6 @@ namespace RTLTMPro
             EditorGUILayout.BeginHorizontal();
             EditorGUI.BeginChangeCheck();
             farsiProp.boolValue = GUILayout.Toggle(farsiProp.boolValue, new GUIContent("Farsi"));
-            forceFixProp.boolValue = GUILayout.Toggle(forceFixProp.boolValue, new GUIContent("Force Fix"));
             preserveNumbersProp.boolValue = GUILayout.Toggle(preserveNumbersProp.boolValue, new GUIContent("Preserve Numbers"));
 
             if (tmpro.richText)

--- a/UPMPackage/Scripts/Runtime/RTLTMPro.asmdef
+++ b/UPMPackage/Scripts/Runtime/RTLTMPro.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "RTLTMPro",
+    "rootNamespace": "",
     "references": [
-        "Unity.TextMeshPro"
+        "Unity.TextMeshPro",
+        "Unity.Localization"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
@@ -114,7 +114,8 @@ namespace RTLTMPro
             {
                 isRightToLeftText = false;
                 base.text = GetChunkFixedText(originalText);
-            } else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
+            } 
+            else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
                 base.text = GetFixedText(originalText);
@@ -130,7 +131,7 @@ namespace RTLTMPro
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            string recombinedString = "";
+            FastStringBuilder recombinedString = new FastStringBuilder("");
             List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
 
             FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
@@ -149,7 +150,7 @@ namespace RTLTMPro
                 }
                 else
                 {
-                    recombinedString += chunks[i];  // If LTR chunk, just append
+                    recombinedString += chunks[i]; // If LTR chunk, just append
                 }
             }
 

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
@@ -1,5 +1,6 @@
 ﻿using TMPro;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace RTLTMPro
 {
@@ -112,7 +113,7 @@ namespace RTLTMPro
             if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
             {
                 isRightToLeftText = false;
-                base.text = originalText;
+                base.text = GetChunkFixedText(originalText);
             } else if(originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
@@ -122,6 +123,37 @@ namespace RTLTMPro
             }
 
             havePropertiesChanged = true;
+        }
+
+        private string GetChunkFixedText(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            string recombinedString = "";
+            List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
+
+            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+
+            // Loop over chunks. Fix RTL and just append LTR
+            for (int i = 0; i < chunks.Count; i++)
+            {
+                if (TextUtils.IsRTLInput(chunks[i]))
+                {
+                    arChunkFixer.Clear();
+
+                    // Fix the Arabic block of text
+                    RTLSupport.FixRTL(chunks[i], arChunkFixer, farsi, fixTags, preserveNumbers);
+
+                    recombinedString += arChunkFixer.ToString();
+                }
+                else
+                {
+                    recombinedString += chunks[i];  // If LTR chunk, just append
+                }
+            }
+
+            return recombinedString;
         }
 
         private string GetFixedText(string input)

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro.cs
@@ -1,6 +1,7 @@
-﻿using TMPro;
+﻿using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
-using System.Collections.Generic;
+using UnityEngine.Localization.Settings;
 
 namespace RTLTMPro
 {
@@ -70,17 +71,9 @@ namespace RTLTMPro
             }
         }
 
-        public bool ForceFix
+        private static bool ForceFix
         {
-            get { return forceFix; }
-            set
-            {
-                if (forceFix == value)
-                    return;
-
-                forceFix = value;
-                havePropertiesChanged = true;
-            }
+            get => LocalizationSettings.SelectedLocale != null && LocalizationSettings.SelectedLocale.Identifier.CultureInfo.TextInfo.IsRightToLeft;
         }
 
         [SerializeField] protected bool preserveNumbers = true;
@@ -110,7 +103,7 @@ namespace RTLTMPro
             if (originalText == null)
                 originalText = "";
 
-            if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
+            if (!ForceFix)
             {
                 isRightToLeftText = false;
                 base.text = GetChunkFixedText(originalText);

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -131,15 +131,14 @@ namespace RTLTMPro
             if (string.IsNullOrEmpty(input))
                 return input;
 
-            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
-
-            string recombinedString = "";
+            FastStringBuilder recombinedString = new FastStringBuilder("");
             List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
+
+            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
 
             // Loop over chunks. Fix RTL and just append LTR
             for (int i = 0; i < chunks.Count; i++)
             {
-
                 if (TextUtils.IsRTLInput(chunks[i]))
                 {
                     arChunkFixer.Clear();
@@ -151,7 +150,7 @@ namespace RTLTMPro
                 }
                 else
                 {
-                    recombinedString += chunks[i];  // If LTR chunk, just append
+                    recombinedString += chunks[i]; // If LTR chunk, just append
                 }
             }
 

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -1,6 +1,7 @@
-﻿using TMPro;
+﻿using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
-using System.Collections.Generic;
+using UnityEngine.Localization.Settings;
 
 namespace RTLTMPro
 {
@@ -70,17 +71,9 @@ namespace RTLTMPro
             }
         }
 
-        protected bool ForceFix
+        private static bool ForceFix
         {
-            get { return forceFix; }
-            set
-            {
-                if (forceFix == value)
-                    return;
-
-                forceFix = value;
-                havePropertiesChanged = true;
-            }
+            get => LocalizationSettings.SelectedLocale != null && LocalizationSettings.SelectedLocale.Identifier.CultureInfo.TextInfo.IsRightToLeft;
         }
 
         [SerializeField] protected bool preserveNumbers;
@@ -110,11 +103,11 @@ namespace RTLTMPro
             if (originalText == null)
                 originalText = "";
 
-            if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
+            if (!ForceFix)
             {
                 isRightToLeftText = false;
                 base.text = GetChunkFixedText(originalText);
-            }
+            } 
             else if (originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
                 isRightToLeftText = true;
@@ -165,7 +158,6 @@ namespace RTLTMPro
             finalText.Clear();
             RTLSupport.FixRTL(input, finalText, farsi, fixTags, preserveNumbers);
             finalText.Reverse();
-
             return finalText.ToString();
         }
     }

--- a/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
+++ b/UPMPackage/Scripts/Runtime/RTLTextMeshPro3D.cs
@@ -1,5 +1,6 @@
 ﻿using TMPro;
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace RTLTMPro
 {
@@ -112,7 +113,7 @@ namespace RTLTMPro
             if (ForceFix == false && TextUtils.IsRTLInput(originalText) == false)
             {
                 isRightToLeftText = false;
-                base.text = originalText;
+                base.text = GetChunkFixedText(originalText);
             }
             else if (originalText != resultOfLastProcess)  // If originalText == resultOfLastProcess, we're trying to process a string for a second time
             {
@@ -123,6 +124,38 @@ namespace RTLTMPro
             }
 
             havePropertiesChanged = true;
+        }
+
+        private string GetChunkFixedText(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return input;
+
+            FastStringBuilder arChunkFixer = new FastStringBuilder(RTLSupport.DefaultBufferSize);
+
+            string recombinedString = "";
+            List<string> chunks = TextUtils.SplitLtrRtlChunks(input);
+
+            // Loop over chunks. Fix RTL and just append LTR
+            for (int i = 0; i < chunks.Count; i++)
+            {
+
+                if (TextUtils.IsRTLInput(chunks[i]))
+                {
+                    arChunkFixer.Clear();
+
+                    // Fix the Arabic block of text
+                    RTLSupport.FixRTL(chunks[i], arChunkFixer, farsi, fixTags, preserveNumbers);
+
+                    recombinedString += arChunkFixer.ToString();
+                }
+                else
+                {
+                    recombinedString += chunks[i];  // If LTR chunk, just append
+                }
+            }
+
+            return recombinedString;
         }
 
         private string GetFixedText(string input)

--- a/UPMPackage/Scripts/Runtime/TextUtils.cs
+++ b/UPMPackage/Scripts/Runtime/TextUtils.cs
@@ -455,8 +455,13 @@ namespace RTLTMPro
                 // Loop and add a chunk each time that the text switches between RTL and LTR
                 for (int i = 1; i < input.Length; i++)      //  Start at char 1
                 {
-                    if (IsRTLCharacter(input[i]) == rtlChunk){
-
+                    //if (IsRTLCharacter(input[i]) == rtlChunk){
+                    if (IsRTLCharacter(input[i]) == rtlChunk)
+                    {
+                        buffer += input[i];
+                    }
+                    else if (input[i] == ' ')   // Prevent space breaking Arabic strings into chunks
+                    {
                         buffer += input[i];
                     }
                     else

--- a/UPMPackage/Scripts/Runtime/TextUtils.cs
+++ b/UPMPackage/Scripts/Runtime/TextUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections;
 
 namespace RTLTMPro
 {
@@ -432,11 +433,54 @@ namespace RTLTMPro
 
                 if (char.IsLetter(character))
                 {
-                    if (IsRTLCharacter(character)) return true;
+                    //if (IsRTLCharacter(character)) return true;
+
+                    return IsRTLCharacter(character);
                 }
             }
 
             return false;
+        }
+
+        public static List<string> SplitLtrRtlChunks(string input)
+        {
+            List<string> chunks = new List<string>();
+
+            if (input.Length > 0)
+            {
+                string buffer = "";
+                buffer += input[0];                         // Initialise with char 0
+                bool rtlChunk = IsRTLCharacter(input[0]);
+
+                // Loop and add a chunk each time that the text switches between RTL and LTR
+                for (int i = 1; i < input.Length; i++)      //  Start at char 1
+                {
+                    if (IsRTLCharacter(input[i]) == rtlChunk){
+
+                        buffer += input[i];
+                    }
+                    else
+                    {
+                        // Change between RTL and LTR
+                        chunks.Add(buffer);
+
+                        buffer = "";
+                        buffer += input[i];
+                        rtlChunk = IsRTLCharacter(input[i]);
+                    }
+                }
+
+                if (buffer.Length > 0)  // Flush the buffer
+                {
+                    chunks.Add(buffer);
+                }
+            }
+            else
+            {
+                chunks.Add(input);  // Adding an empty string
+            }
+
+            return chunks;
         }
     }
 }

--- a/UPMPackage/Scripts/Runtime/TextUtils.cs
+++ b/UPMPackage/Scripts/Runtime/TextUtils.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections;
 
 namespace RTLTMPro
 {
@@ -32,8 +31,8 @@ namespace RTLTMPro
         private const char ArabicPresentationFormsBBlockLow  = (char)0xFE70;
         private const char ArabicPresentationFormsBBlockHigh = (char)0xFEFF;
 
-        private const char LeftGuillemet = '\u00AB';  // «
-        private const char RightGuillemet = '\u00BB'; // »
+        private const char LeftGuillemet = '\u00AB';  // ï¿½
+        private const char RightGuillemet = '\u00BB'; // ï¿½
 
         public static bool IsPunctuation(char ch)
         {
@@ -407,7 +406,7 @@ namespace RTLTMPro
         }
         
         /// <summary>
-        ///     Checks if the input string starts with supported RTL character or not.
+        /// Checks if the input string starts with supported RTL character or not.
         /// </summary>
         /// <returns><see langword="true" /> if input is RTL. otherwise <see langword="false" /></returns>
         public static bool IsRTLInput(string input)
@@ -433,8 +432,6 @@ namespace RTLTMPro
 
                 if (char.IsLetter(character))
                 {
-                    //if (IsRTLCharacter(character)) return true;
-
                     return IsRTLCharacter(character);
                 }
             }
@@ -448,21 +445,38 @@ namespace RTLTMPro
 
             if (input.Length > 0)
             {
-                string buffer = "";
+                FastStringBuilder buffer = "";
                 buffer += input[0];                         // Initialise with char 0
                 bool rtlChunk = IsRTLCharacter(input[0]);
 
                 // Loop and add a chunk each time that the text switches between RTL and LTR
                 for (int i = 1; i < input.Length; i++)      //  Start at char 1
                 {
-                    //if (IsRTLCharacter(input[i]) == rtlChunk){
+                    if (input[i] == ' ' && i < input.Length - 1)
+                    {
+                        if (!rtlChunk)
+                        {
+                            buffer.Append(input[i]);
+                            continue;
+                        }
+                        
+                        if (IsRTLCharacter(input[i + 1]))
+                        {
+                            buffer.Append(input[i]);
+                        }
+                        else
+                        {
+                            chunks.Add(buffer);
+                            buffer.Clear();
+                            buffer.Append(input[i]);
+                            rtlChunk = false;
+                        }
+                        continue;
+                    }
+
                     if (IsRTLCharacter(input[i]) == rtlChunk)
                     {
-                        buffer += input[i];
-                    }
-                    else if (input[i] == ' ')   // Prevent space breaking Arabic strings into chunks
-                    {
-                        buffer += input[i];
+                        buffer.Append(input[i]);
                     }
                     else
                     {

--- a/UPMPackage/Tests/EngageOrderingTests.cs
+++ b/UPMPackage/Tests/EngageOrderingTests.cs
@@ -30,11 +30,23 @@ namespace RTLTMPro.Tests
         [TestCase("(المريخ).", ")ﺍﻟﻤﺮﯾﺦ(.")]
         [TestCase("هل أنت متأكد أنك تريد حذف \"موسيقىaaa\"؟", "ﻫﻞ ﺃﻧﺖ ﻣﺘﺄﻛﺪ ﺃﻧﻚ ﺗﺮﯾﺪ ﺣﺬﻑ \"ﻣﻮﺳﯿﻘﻰaaa\"؟")]
         [TestCase("هل أنت متأكد أنك تريد حذف \"aaaموسيقى\"؟", "ﻫﻞ ﺃﻧﺖ ﻣﺘﺄﻛﺪ ﺃﻧﻚ ﺗﺮﯾﺪ ﺣﺬﻑ \"aaaﻣﻮﺳﯿﻘﻰ\"؟")]
-        [TestCase("المحور المركزي لـ ENGAGE LINK. نحن نعقد جلسات \"تعلم ENGAGE\" هنا بشكل متكرر، بالإضافة إلى حلقات عمل وفعاليات تواصل أخرى. لمزيد من المعلومات، تحقق من لوحات الملاحظات.", "ﺍﻟﻤﺤﻮﺭ ﺍﻟﻤﺮﻛﺰﯼ ﻟـ KNIL EGAGNE. ﻧﺤﻦ ﻧﻌﻘﺪ ﺟﻠﺴﺎﺕ \"ﺗﻌﻠﻢ EGAGNE\" ﻫﻨﺎ ﺑﺸﻜﻞ ﻣﺘﻜﺮﺭ، ﺑﺎﻹﺿﺎﻓﺔ ﺇﻟﻰ ﺣﻠﻘﺎﺕ ﻋﻤﻞ ﻭﻓﻌﺎﻟﯿﺎﺕ ﺗﻮﺍﺻﻞ ﺃﺧﺮﻯ. ﻟﻤﺰﯾﺪ ﻣﻦ ﺍﻟﻤﻌﻠﻮﻣﺎﺕ، ﺗﺤﻘﻖ ﻣﻦ ﻟﻮﺣﺎﺕ ﺍﻟﻤﻼﺣﻈﺎﺕ.")]
         public void CharacterOrder(string input, string expected)
         {
             // Act
             string result = SimulatedUpdateText(input, true, true, true);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestCase("A recording is in progress by عبد. Your voice, actions, and movements might be recorded.", "A recording is in progress by ﺪﺒﻋ. Your voice, actions, and movements might be recorded.")]
+        [TestCase("Bring all users to قاعة المحاضرات", "Bring all users to ﺕﺍﺮﺿﺎﺤﻤﻟﺍ ﺔﻋﺎﻗ")]
+        public void RTLTextInLTRStrings(string input, string expected)
+        {
+            // Act
+            RTLTextMeshPro rtlTMPro = new RTLTextMeshPro();
+            rtlTMPro.text = input;
+            string result = rtlTMPro.text;
 
             // Assert
             Assert.AreEqual(expected, result);

--- a/UPMPackage/package.json
+++ b/UPMPackage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.engage.rtltmpro",
   "displayName": "RTL Text Mesh Pro",
-  "version": "3.4.6",
+  "version": "3.4.6-engage.2",
   "unity": "2022.3",
   "description": "This package adds Right-to-left language support to TextMeshPro Unity package. Supports Persian, Arabic and Hebrew.",
   "keywords": [


### PR DESCRIPTION
I needed to add some extra bits from the version previously shared.

RTLTextMeshPro / RTLTextMeshPro3D : ln 143 : Need to clear the FastStringBuilder for each chunk

TextUtils : ln 463 : The space character isn't classed as RTL, so it was splitting sequences of Arabic words and reversing the order. This should maybe be a list of characters to ignore.