### PR TITLE
Added support for non-breaking space character

### DIFF
--- a/Assets/RTLTMPro/Scripts/Runtime/Char32Utils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/Char32Utils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace RTLTMPro {
     public static class Char32Utils {
@@ -40,6 +41,7 @@ namespace RTLTMPro {
 
         public static bool IsPunctuation(int ch) {
             if (!IsUnicode16Char(ch)) return false;
+            if (ch == '\u00A0') return true;
             return char.IsPunctuation((char)ch);
         }
 

--- a/Assets/RTLTMPro/Scripts/Runtime/Char32Utils.cs
+++ b/Assets/RTLTMPro/Scripts/Runtime/Char32Utils.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using UnityEngine;
 
 namespace RTLTMPro {
     public static class Char32Utils {

--- a/UPMPackage/Scripts/Runtime/Char32Utils.cs
+++ b/UPMPackage/Scripts/Runtime/Char32Utils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using UnityEngine;
 
 namespace RTLTMPro {
     public static class Char32Utils {
@@ -40,6 +41,7 @@ namespace RTLTMPro {
 
         public static bool IsPunctuation(int ch) {
             if (!IsUnicode16Char(ch)) return false;
+            if (ch == '\u00A0') return true;
             return char.IsPunctuation((char)ch);
         }
 

--- a/UPMPackage/Scripts/Runtime/Char32Utils.cs
+++ b/UPMPackage/Scripts/Runtime/Char32Utils.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using UnityEngine;
 
 namespace RTLTMPro {
     public static class Char32Utils {


### PR DESCRIPTION
There was feedback from KWS to fix some word ordering on the ENGAGE LINK map:

![image](https://github.com/user-attachments/assets/3757023f-e022-47f2-997e-972b0806c14d)

The word ordering is actually correct, but looks odd because of the line break. I added a non-breaking space in the string, but because the library didn't recognise the character, it flipped the word order:

![image](https://github.com/user-attachments/assets/51d79f29-3a6a-47a3-a8dc-d543320f9046)

This fix adds recognition of the NBS character as punctuation. An alternative would be to remove the NBS from the string and just accept the line break in the word. Result of the fix:

![image](https://github.com/user-attachments/assets/5235fc20-5062-4a8e-a88e-85606b593b73)
![image](https://github.com/user-attachments/assets/2a79e8e6-ae92-4875-8c4c-0e6029fe3867)
