### PR TITLE
EN-44102 / Fix ArgumentOutOfRangeException

### DIFF
--- a/Runtime/FastStringBuilder.cs
+++ b/Runtime/FastStringBuilder.cs
@@ -205,10 +205,16 @@ namespace RTLTMPro
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();
+
             for (int i = 0; i < length; i++)
             {
-                sb.Append(char.ConvertFromUtf32(array[i]));
+                try
+                {
+                    sb.Append(char.ConvertFromUtf32(array[i]));
+                }
+                catch (Exception) { /* Avoid any conversion exception */ }
             }
+
             return sb.ToString();
         }
 


### PR DESCRIPTION
[EN-44102 / All Devices - Media - User sees blue spinner on YouTube search](https://vreducation.atlassian.net/browse/EN-44102)

An ArgumentOutOfRangeException was being thrown in FastStringBuilder, causing different visual issues on Engage