### PR TITLE
Added support for RTL override character.

### DIFF
--- a/Runtime/TextUtils.cs
+++ b/Runtime/TextUtils.cs
@@ -86,6 +86,7 @@ namespace RTLTMPro
         /// <returns><see langword="true" /> if character is supported. otherwise <see langword="false" /></returns>
         public static bool IsRTLCharacter(char ch)
         {
+            if (ch == '\u202E') return true;        // RTL override character
             if (IsHebrewCharacter(ch)) return true;
             if (IsArabicCharacter(ch)) return true;
             return false;


### PR DESCRIPTION
Like a broken record, I'm suggesting that we add support for the RTL override character. It'll let us fix formatting anomalies in the strings.

E.g., closing bracket placed after a URL, and double space before YouTube. 
![image](https://github.com/user-attachments/assets/af67ed38-6d34-4b7a-b3a9-323259da34a5)

Adding RTLO characters at strategic points in the string forces a fix:
![image](https://github.com/user-attachments/assets/4f9754a1-e9a3-418c-8d2e-00247195d157)

We'd need to make sure that it doesn't actually appear in the string. It shouldn't have a character:
![image](https://github.com/user-attachments/assets/5d344e40-70a1-4262-a76e-e19c7520cd29)

I'm not sure about how to fix this otherwise. Maybe the Arabic translator could rewrite it so there's some Arabic text before the closing bracket.