### PR TITLE
EN-44271 / Fix UTF 32 Conversion Issue

### DIFF
--- a/Runtime/FastStringBuilder.cs
+++ b/Runtime/FastStringBuilder.cs
@@ -67,12 +67,17 @@ namespace RTLTMPro
 
             for (int i = 0; i < text.Length; i++)
             {
-                int unicode32CodePoint = char.ConvertToUtf32(text, i);
-                if (unicode32CodePoint > 0xffff)
+                try
                 {
-                    i++;
+                    int unicode32CodePoint = char.ConvertToUtf32(text, i);
+
+                    if (unicode32CodePoint > 0xffff)
+                    {
+                        i++;
+                    }
+                    array[len++] = unicode32CodePoint;
                 }
-                array[len++] = unicode32CodePoint;
+                catch (Exception) { /* Avoid any conversion exception */ }
             }
 
             length = len;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.engage.rtltmpro",
   "displayName": "RTL Text Mesh Pro",
-  "version": "3.4.6-engage.5",
+  "version": "3.4.6-engage.6",
   "unity": "2022.3",
   "description": "This package adds Right-to-left language support to TextMeshPro Unity package. Supports Persian, Arabic and Hebrew.",
   "keywords": [


### PR DESCRIPTION
[EN-44271 / All Devices - Media - Searching for live stream only shows first result and spinner](https://vreducation.atlassian.net/browse/EN-44271)

There was another UTF32 conversion left unprotected in `FastStringBuilder`, throwing a `System.ArgumentException` when trying to display some video result titles in the YouTube search screen.